### PR TITLE
Fix gem version to support rubygems < 2.1

### DIFF
--- a/lib/metasploit/erd/version.rb
+++ b/lib/metasploit/erd/version.rb
@@ -25,7 +25,19 @@ module Metasploit
 
         version
       end
+
+      # The full gem version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
+      # {http://guides.rubygems.org/specification-reference/#version RubyGems versioning} format.
+      #
+      # @return [String] '{MAJOR}.{MINOR}.{PATCH}' on master.  '{MAJOR}.{MINOR}.{PATCH}.{PRERELEASE}' on any branch
+      #   other than master.
+      def self.gem
+        full.gsub('-', '.pre.')
+      end
     end
+
+    # @see Version.gem
+    GEM_VERSION = Version.gem
 
     # @see Version.full
     VERSION = Version.full

--- a/metasploit-erd.gemspec
+++ b/metasploit-erd.gemspec
@@ -5,7 +5,7 @@ require 'metasploit/erd/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'metasploit-erd'
-  spec.version       = Metasploit::ERD::VERSION
+  spec.version       = Metasploit::ERD::GEM_VERSION
   spec.authors       = ['Luke Imhoff']
   spec.email         = ['luke_imhoff@rapid7.com']
   spec.summary       = 'Extensions to rails-erd to find clusters of models to generate subdomains specific to each model'


### PR DESCRIPTION
https://jira.tor.rapid7.com/browse/MSP-10714
## Verification Steps
- [x] `gem update --system 1.8.23`
- [x] `bundle`
- [x] VERIFY: bundle completes successfully
## Land
- [x] Merge this PR
- [x] Remove `PRERELEASE` constant and comment from `lib/metasploit/erd/version.rb`.  Commit and push.
