### PR TITLE
Fix rails 4.1 deprecation

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,10 +8,10 @@ require 'coveralls'
 #   # don't generate local report as it is inaccessible on travis-ci, which is why coveralls is being used.
 #   SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 # else
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
       # either generate the local report
       SimpleCov::Formatter::HTMLFormatter
-  ]
+  )
 # end
 
 #


### PR DESCRIPTION
Where the [] syntax needed to be changed to the .new syntax