### PR TITLE
update to support rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ addons:
     packages:
       - graphviz
 rvm:
-  - 2.3.2
+  - 2.6.5
 before_install:
-  - gem update bundler
+  - gem install bundler
 script:
   - bundle exec rake spec
   - bundle exec rake yard

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ end
 
 group :test do
   # blank?
-  gem 'activesupport', '~> 4.2.6'
+  gem 'activesupport', '~> 5.2.2'
   # Upload coverage reports to coveralls.io
   gem 'coveralls', require: false
   # code coverage of tests

--- a/lib/metasploit/erd/version.rb
+++ b/lib/metasploit/erd/version.rb
@@ -1,7 +1,7 @@
 module Metasploit
   module ERD
     # VERSION is managed by GemRelease
-    VERSION = '2.0.6'
+    VERSION = '3.0.0'
 
     # @return [String]
     #

--- a/metasploit-erd.gemspec
+++ b/metasploit-erd.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'metasploit-yard'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.2'
+  spec.add_development_dependency 'rspec'
 
-  spec.add_runtime_dependency 'activerecord', '~> 4.2.6'
-  spec.add_runtime_dependency 'activesupport', '~> 4.2.6'
-  spec.add_runtime_dependency 'rails-erd', '~> 1.1'
+  spec.add_runtime_dependency 'activerecord', '~> 5.2.2'
+  spec.add_runtime_dependency 'activesupport', '~> 5.2.2'
+  spec.add_runtime_dependency 'rails-erd'
 end


### PR DESCRIPTION
Updates dependencies to support Rails 5.2.

Due to compatibility options for Rails dependency this reflects a breaking change.

Set version to `3.0.0`, open to input on version as `2.1.0` since no actual code changes.
