### PR TITLE
update to Rails 6.0 compatible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ group :development do
 end
 
 group :test do
-  # blank?
-  gem 'activesupport', '~> 5.2.2'
   # code coverage of tests
   gem 'simplecov', :require => false
   # in-memory database for ActiveRecord association traversal

--- a/lib/metasploit/erd/entity/namespace.rb
+++ b/lib/metasploit/erd/entity/namespace.rb
@@ -31,7 +31,7 @@ class Metasploit::ERD::Entity::Namespace
   # @return [Array<Class<ActiveRecord::Base>
   def classes
     ActiveRecord::Base.descendants.select { |klass|
-      klass.parents.any? { |parent|
+      klass.module_parents.any? { |parent|
         parent.name == namespace_name
       }
     }

--- a/lib/metasploit/erd/version.rb
+++ b/lib/metasploit/erd/version.rb
@@ -1,7 +1,7 @@
 module Metasploit
   module ERD
     # VERSION is managed by GemRelease
-    VERSION = '3.0.3'
+    VERSION = '4.0.0'
 
     # @return [String]
     #

--- a/metasploit-erd.gemspec
+++ b/metasploit-erd.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
 
-  spec.add_runtime_dependency 'activerecord', '~> 5.2.2'
-  spec.add_runtime_dependency 'activesupport', '~> 5.2.2'
+  spec.add_runtime_dependency 'activerecord', '~> 6.0'
+  spec.add_runtime_dependency 'activesupport', '~> 6.0'
   spec.add_runtime_dependency 'rails-erd'
 end

--- a/spec/metasploit/erd/relationship_spec.rb
+++ b/spec/metasploit/erd/relationship_spec.rb
@@ -124,13 +124,10 @@ RSpec.describe Metasploit::ERD::Relationship do
 
           ActiveRecord::Migration.create_table :owners do |t|
             t.references :thing
-
-            t.timestamp
           end
 
           things.each do |thing|
             ActiveRecord::Migration.create_table thing.table_name do |t|
-              t.timestamp
             end
           end
         end
@@ -210,8 +207,6 @@ RSpec.describe Metasploit::ERD::Relationship do
         group_names.each do |group_name|
           t.references group_name.underscore.to_sym
         end
-
-        t.timestamp
       end
 
       polymorphics_by_group_name.each do |group_name, polymorphics|

--- a/spec/support/shared/contexts/active_record_base_connection.rb
+++ b/spec/support/shared/contexts/active_record_base_connection.rb
@@ -7,6 +7,6 @@ RSpec.shared_context 'ActiveRecord::Base connection' do
   end
 
   after(:example) do
-    ActiveRecord::Base.connection.disconnect!
+    ActiveRecord::Base.connection.disconnect! rescue nil
   end
 end

--- a/spec/support/shared/contexts/active_record_base_descendants_cleaner.rb
+++ b/spec/support/shared/contexts/active_record_base_descendants_cleaner.rb
@@ -6,6 +6,12 @@ RSpec.shared_context 'ActiveRecord::Base.descendants cleaner' do
   after(:example) do
     # `ActiveSupport::DescendantsTracker.clear` will not clear ActiveRecord::Base subclasses because
     # ActiveSupport::Dependencies is loaded
-    ActiveRecord::Base.direct_descendants.clear
+    if ActiveRecord.version >= Gem::Version.new("6.0.0.rc1")
+      cv = ActiveSupport::DescendantsTracker.class_variable_get(:@@direct_descendants)
+      cv.delete(ActiveRecord::Base)
+      ActiveSupport::DescendantsTracker.class_variable_set(:@@direct_descendants, cv)
+    else
+      ActiveRecord::Base.direct_descendants.clear
+    end
   end
 end


### PR DESCRIPTION
Updates gem support for Rails 6.x

* timestamp is no longer accessible on a created table
* Clearing decedents has changed. 